### PR TITLE
Feature/structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN apt-get clean
 # Filesystem
 COPY . /src
 
+# Env vars for compilation
+ENV API__URL=https://api.haar.io/
+ENV APP__URL=https://www.haar.io/
+ENV NODE_ENV=production
+
 # Install dependancies
 RUN cd /src; npm install;
 RUN cd /src; npm run compile;

--- a/bin/watch
+++ b/bin/watch
@@ -4,7 +4,7 @@
 PATH=$(npm bin):$PATH
 
 # Watch scss files
-stylus lib/index.styl -o dist/css/style.css -c -u autoprefixer-stylus -w &
+stylus lib/index.styl -o dist/css/style.css -u autoprefixer-stylus -w &
 
 # Watch JS files
 webpack --watch

--- a/package.json
+++ b/package.json
@@ -17,23 +17,20 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "autoprefixer-stylus": "^0.9.2",
-    "babel-core": "^6.7.2",
     "babel-eslint": "^6.0.0",
-    "babel-loader": "^6.2.4",
     "chai": "^3.5.0",
     "eslint": "^2.5.3",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.2.3",
     "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
-    "node-sass": "^3.4.2",
-    "pre-commit": "^1.1.2",
-    "stylus": "^0.54.2",
-    "webpack": "^1.12.14"
+    "pre-commit": "^1.1.2"
   },
   "dependencies": {
+    "autoprefixer-stylus": "^0.9.2",
     "axios": "^0.9.1",
+    "babel-core": "^6.7.2",
+    "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.7.2",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
@@ -55,7 +52,9 @@
     "react-router": "^2.0.1",
     "redux": "^3.3.1",
     "redux-form": "^4.2.2",
-    "redux-thunk": "^2.0.1"
+    "redux-thunk": "^2.0.1",
+    "stylus": "^0.54.2",
+    "webpack": "^1.12.14"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
`docker-compose` does not allow for dynamic replacement of ENV vars at build-time. Since our ENV vars are not secret, they have been embedded in the Dockerfile.
- update Dockerfile to include ENV vars
- shift NPM dependencies around
